### PR TITLE
ignore unknown json properties in dtos

### DIFF
--- a/src/main/java/it/gdorsi/openaiclient/dto/AssistantRequestDTO.java
+++ b/src/main/java/it/gdorsi/openaiclient/dto/AssistantRequestDTO.java
@@ -1,3 +1,8 @@
 package it.gdorsi.openaiclient.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record AssistantRequestDTO(String model, String instructions) {}
+
+

--- a/src/main/java/it/gdorsi/openaiclient/dto/AssistantResponseDTO.java
+++ b/src/main/java/it/gdorsi/openaiclient/dto/AssistantResponseDTO.java
@@ -1,10 +1,12 @@
 package it.gdorsi.openaiclient.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 import java.util.Map;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record AssistantResponseDTO(
         String id,
         String object,

--- a/src/main/java/it/gdorsi/openaiclient/dto/MessageDTO.java
+++ b/src/main/java/it/gdorsi/openaiclient/dto/MessageDTO.java
@@ -1,3 +1,6 @@
 package it.gdorsi.openaiclient.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record MessageDTO(String role, String content) {}

--- a/src/main/java/it/gdorsi/openaiclient/dto/MessageResponseDTO.java
+++ b/src/main/java/it/gdorsi/openaiclient/dto/MessageResponseDTO.java
@@ -1,10 +1,12 @@
 package it.gdorsi.openaiclient.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 import java.util.Map;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record MessageResponseDTO(
         String id,
         String object,

--- a/src/main/java/it/gdorsi/openaiclient/dto/MessagesListResponseDTO.java
+++ b/src/main/java/it/gdorsi/openaiclient/dto/MessagesListResponseDTO.java
@@ -1,9 +1,11 @@
 package it.gdorsi.openaiclient.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record MessagesListResponseDTO(
         String object,
         List<MessageResponseDTO> data,

--- a/src/main/java/it/gdorsi/openaiclient/dto/RunRequestDTO.java
+++ b/src/main/java/it/gdorsi/openaiclient/dto/RunRequestDTO.java
@@ -1,7 +1,9 @@
 package it.gdorsi.openaiclient.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record RunRequestDTO (
         @JsonProperty("assistant_id")
         String assistantId) {}

--- a/src/main/java/it/gdorsi/openaiclient/dto/RunResponseDTO.java
+++ b/src/main/java/it/gdorsi/openaiclient/dto/RunResponseDTO.java
@@ -1,11 +1,13 @@
 package it.gdorsi.openaiclient.dto;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 import java.util.Map;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record RunResponseDTO(
         String id,
         String object,

--- a/src/main/java/it/gdorsi/openaiclient/dto/ThreadDTO.java
+++ b/src/main/java/it/gdorsi/openaiclient/dto/ThreadDTO.java
@@ -1,3 +1,6 @@
 package it.gdorsi.openaiclient.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record ThreadDTO() {}

--- a/src/main/java/it/gdorsi/openaiclient/dto/ThreadResponseDTO.java
+++ b/src/main/java/it/gdorsi/openaiclient/dto/ThreadResponseDTO.java
@@ -1,9 +1,11 @@
 package it.gdorsi.openaiclient.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Map;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record ThreadResponseDTO(
         String id,
         String object,


### PR DESCRIPTION
The DTOs are quickly becoming outdated because the API is changing. I suggest adding the annotation @JsonIgnoreProperties(ignoreUnknown = true) so that the client continues to function even when new attributes are added to the API.